### PR TITLE
Add custom domain cubingmexico.(org|com) to allowed hosts

### DIFF
--- a/web/cubingmexico/settings.py
+++ b/web/cubingmexico/settings.py
@@ -68,9 +68,21 @@ SECRET_KEY = env("SECRET_KEY")
 if os.getenv("PYTHON_ENV") == "dev":
     ALLOWED_HOSTS = ['localhost', '127.0.0.1']
 else:
-    ALLOWED_HOSTS = ['cubingmexico-p3uk45s5ka-uc.a.run.app']
+    ALLOWED_HOSTS = [
+        'cubingmexico-p3uk45s5ka-uc.a.run.app',
+        'cubingmexico.com',
+        'www.cubingmexico.com',
+        'cubingmexico.org',
+        'www.cubingmexico.org',
+    ]
 
-CSRF_TRUSTED_ORIGINS = ['https://cubingmexico-p3uk45s5ka-uc.a.run.app']
+CSRF_TRUSTED_ORIGINS = [
+    'https://cubingmexico-p3uk45s5ka-uc.a.run.app',
+    'https://cubingmexico.com',
+    'https://www.cubingmexico.com',
+    'https://cubingmexico.org',
+    'https://www.cubingmexico.org',
+]
 
 # Application definition
 


### PR DESCRIPTION
Hi Leo,

This is to allow requests from the custom domains I configured in the cloud run service in your GCP project. I also set the DNS hosts in the provider.

Not sure about the WCA callback though.

I'm wondering if the code is outdated since cubingmexico-p3uk45s5ka-uc is not available anymore.


Please let me know if you have any concerns or suggestions. I've allowed edits in the PR if you want to make some edits.


Lucero.